### PR TITLE
String Safety

### DIFF
--- a/deps/mexjulia.cpp
+++ b/deps/mexjulia.cpp
@@ -84,9 +84,9 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
             mexErrMsgTxt(dlerror());
           }
         #endif
-        jl_init_with_image(strdup(home), strdup(image));
-        mxFree(home);
-        mxFree(image);
+        jl_init_with_image(home, image);
+        mxFree(lib);
+        // home/image intentionally not freed (libjulia expects them to live forever)
         mexAtExit(jl_atexit_hook_0);
       }
     }

--- a/deps/mexjulia.cpp
+++ b/deps/mexjulia.cpp
@@ -84,7 +84,7 @@ void mexFunction(int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[])
             mexErrMsgTxt(dlerror());
           }
         #endif
-        jl_init_with_image(home, image);
+        jl_init_with_image(strdup(home), strdup(image));
         mxFree(home);
         mxFree(image);
         mexAtExit(jl_atexit_hook_0);


### PR DESCRIPTION
Use `strdup` for string safety.

@topolarity also saw that `lib` wasn't being handled properly, and that if this function doesn't finish then there's a memory leak.
